### PR TITLE
rspec-legacy_formatters gem required for this

### DIFF
--- a/rspec_html_reporter.gemspec
+++ b/rspec_html_reporter.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{lib,resources,templates}/**/*', 'README*', 'LICENSE*'] & `git ls-files -z`.split("\0")
 
   spec.add_runtime_dependency('rspec')
+  spec.add_runtime_dependency('rspec-legacy_formatters')
   spec.add_runtime_dependency('rouge', '~> 1.6')
   spec.add_runtime_dependency('activesupport')
 


### PR DESCRIPTION
Without it you receive the following error:
The RspecHtmlReporter formatter uses the deprecated formatter interface not supported directly by RSpec 3.  To continue to use this formatter you must install the `rspec-legacy_formatters` gem, which provides support for legacy formatters or upgrade the formatter to a compatible version